### PR TITLE
Fix cumulative fast-drift in tick scheduler

### DIFF
--- a/app/src/main/java/xyz/zedler/patrick/tack/metronome/MetronomeEngine.java
+++ b/app/src/main/java/xyz/zedler/patrick/tack/metronome/MetronomeEngine.java
@@ -85,7 +85,8 @@ public class MetronomeEngine {
   private int timerBarIndex, timerBeatIndex, timerSubIndex;
   private long tickIndex, tickIndexPoly, latency, countInStartTime, timerStartTime;
   private long elapsedStartTime, elapsedTime, elapsedPrevious;
-  private long nextScheduleTime, nextPolyScheduleTime;
+  // accumulated in double to avoid fractional-ms truncation drift
+  private double nextScheduleTime, nextPolyScheduleTime;
   private float timerProgress;
   private boolean playing, tempPlaying, isCountingIn, isMuted;
   private boolean showElapsed, resetTimerOnStop, tempoInputKeyboard, tempoTapInstant;
@@ -607,10 +608,11 @@ public class MetronomeEngine {
 
         if (subdivisionPoly < config.getSubdivisionsCount()) {
           // first poly subdivision handled in main tick runnable to keep poly in sync
-          long barInterval = getInterval() * config.getBeatsCount();
-          long step = barInterval / config.getSubdivisionsCount();
+          double tempo = Math.max(config.getTempo(), 1);
+          double barInterval = 60_000.0 * config.getBeatsCount() / tempo;
+          double step = barInterval / config.getSubdivisionsCount();
           nextPolyScheduleTime += step;
-          long delay = nextPolyScheduleTime - System.currentTimeMillis();
+          long delay = (long) (nextPolyScheduleTime - System.currentTimeMillis());
           if (delay < 0) {
             delay = 0;
           }
@@ -665,9 +667,10 @@ public class MetronomeEngine {
         }
         Tick tick = new Tick(tickIndex, beat, subdivision, tickType, muted, false);
 
-        long interval = config.usePolyrhythm()
-            ? getInterval()
-            : getInterval() / config.getSubdivisionsCount();
+        double tempo = Math.max(config.getTempo(), 1);
+        double interval = config.usePolyrhythm()
+            ? 60_000.0 / tempo
+            : 60_000.0 / tempo / config.getSubdivisionsCount();
         nextScheduleTime += interval;
 
         if (tick.beat == 1 && tick.subdivision == 1) {
@@ -675,7 +678,7 @@ public class MetronomeEngine {
           nextPolyScheduleTime = nextScheduleTime - interval;
         }
 
-        long delay = nextScheduleTime - System.currentTimeMillis();
+        long delay = (long) (nextScheduleTime - System.currentTimeMillis());
         if (delay < 0) {
           delay = 0;
         }

--- a/wear/src/main/kotlin/xyz/zedler/patrick/tack/metronome/MetronomeEngine.kt
+++ b/wear/src/main/kotlin/xyz/zedler/patrick/tack/metronome/MetronomeEngine.kt
@@ -49,7 +49,7 @@ class MetronomeEngine(
 
   private var tickIndex: Long = 0
   private var latency: Long = 0
-  private var nextScheduleTime: Long = 0
+  private var nextScheduleTime: Double = 0.0
   private var beatModeVibrate: Boolean = false
   private var alwaysVibrate: Boolean = false
   private var flashScreen: Boolean = false
@@ -133,23 +133,20 @@ class MetronomeEngine(
     audioEngine.play()
     tickIndex = 0
 
-    nextScheduleTime = System.currentTimeMillis()
+    nextScheduleTime = System.currentTimeMillis().toDouble()
 
     tickHandler?.post(object : Runnable {
       override fun run() {
         if (isPlaying) {
           if (tickIndex == 0L) {
             // compensate handler initialization latency
-            nextScheduleTime = System.currentTimeMillis()
+            nextScheduleTime = System.currentTimeMillis().toDouble()
           }
 
-          val interval = getInterval() / getSubdivisionsCount()
+          val interval = 60_000.0 / maxOf(tempo, 1) / getSubdivisionsCount()
           nextScheduleTime += interval
 
-          var delay = nextScheduleTime - System.currentTimeMillis()
-          if (delay < 0) {
-            delay = 0
-          }
+          val delay = (nextScheduleTime - System.currentTimeMillis()).toLong().coerceAtLeast(0)
           tickHandler!!.postDelayed(this, delay)
 
           val tick = performTick()


### PR DESCRIPTION
`(60000 / tempo) / subdivisions` integer-divides twice, so each accumulator step drops a fractional ms and the metronome runs progressively fast -- e.g. 140bpm with triplets is ~0.6% fast (~22s per hour), audible against a reference click within a minute. Tempos and subdivisions whose intervals divide 60000 cleanly (60, 100, 120 plain, 200 plain, etc.) are unaffected.

Switches `nextScheduleTime` to `double` and casts back to `long` only at `postDelayed`. `getInterval()` stays `long` so count-in / timer / UI math is unchanged.